### PR TITLE
Include string header for C++

### DIFF
--- a/src/libgensfile/Archive.hpp
+++ b/src/libgensfile/Archive.hpp
@@ -47,6 +47,7 @@
 #include <cstdio>
 // C++ includes.
 #include <algorithm>
+#include <string>
 
 // TODO: Use the MDP headers for mdp_z_entry_t.
 #ifdef __cplusplus


### PR DESCRIPTION
* <string> include is needed for compilation. Otherwise, compiler will fail on line 178, i.e. it won't be able to find std::string.